### PR TITLE
Allow environment variables to be specified.

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::bail;
 use marathon_api::{task, TaskRequest};
 use std::collections::HashMap;
 
@@ -20,31 +20,37 @@ enum Command {
     },
 }
 
-// Parse a list of arguments given to the -e flag, and returns a map from key to value:
-// - If the argument has the form KEY=VALUE, then (KEY, VALUE) is used
+// Parse an argument given to the -e flag, and returns an optional key-value pair:
+// - If the argument has the form KEY=VALUE, then (KEY, VALUE) is returned
 // - If the argument has the form KEY and KEY exists in the current process' environment, that
 //   value is used
-// - If the arguments has the form KEY and KEY does not exist in the process' environment, the
-//   argument is ignored
+// - If the arguments has the form KEY and KEY does not exist in the process' environment, None is
+//   returned
 //
 // This is the same behaviour used by the `docker run` command.
-fn parse_environment(env: &[String]) -> anyhow::Result<HashMap<String, String>> {
-    env.iter()
-        .filter_map(|arg| {
-            if let Some((key, value)) = arg.split_once("=") {
-                Some(Ok((key.to_owned(), value.to_owned())))
-            } else {
-                use std::env::VarError::*;
-                match std::env::var(arg) {
-                    Ok(value) => Some(Ok((arg.to_owned(), value))),
-                    Err(NotPresent) => None,
-                    Err(NotUnicode(_)) => Some(Err(anyhow!(
-                        "Environment variable {} contains invalid characters",
-                        arg
-                    ))),
-                }
-            }
-        })
+fn parse_environment_arg<E>(arg: &str, getenv: E) -> anyhow::Result<Option<(String, String)>>
+where
+    E: Fn(&str) -> Result<String, std::env::VarError>,
+{
+    if let Some((key, value)) = arg.split_once("=") {
+        Ok(Some((key.to_owned(), value.to_owned())))
+    } else {
+        use std::env::VarError::*;
+        match getenv(arg) {
+            Ok(value) => Ok(Some((arg.to_owned(), value))),
+            Err(NotPresent) => Ok(None),
+            Err(NotUnicode(_)) => bail!("Environment variable {} contains invalid characters", arg),
+        }
+    }
+}
+
+fn parse_environment<S, E>(args: &[S], getenv: E) -> anyhow::Result<HashMap<String, String>>
+where
+    S: AsRef<str>,
+    E: Fn(&str) -> Result<String, std::env::VarError>,
+{
+    args.iter()
+        .filter_map(move |arg| parse_environment_arg(arg.as_ref(), &getenv).transpose())
         .collect()
 }
 
@@ -57,7 +63,7 @@ fn main() -> anyhow::Result<()> {
         } => {
             let result = task::execute(&TaskRequest {
                 cmdline,
-                environment: parse_environment(&environment)?,
+                environment: parse_environment(&environment, |k| std::env::var(k))?,
             })?;
             for l in result.output {
                 println!("{}", l);
@@ -66,4 +72,31 @@ fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assertor::*;
+
+    #[test]
+    fn can_parse_environment() -> anyhow::Result<()> {
+        let pair = |k: &str, v: &str| (k.to_owned(), v.to_owned());
+
+        let env: HashMap<String, String> = HashMap::from([pair("A", "foo"), pair("B", "bar")]);
+        let getenv = |k: &str| env.get(k).cloned().ok_or(std::env::VarError::NotPresent);
+
+        assert_that!(parse_environment(
+            &["A", "B=override", "C", "D=value", "E=key=value"],
+            getenv
+        )?)
+        .contains_exactly(HashMap::from([
+            pair("A", "foo"),
+            pair("B", "override"),
+            pair("D", "value"),
+            pair("E", "key=value"),
+        ]));
+
+        Ok(())
+    }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,4 +1,6 @@
+use anyhow::anyhow;
 use marathon_api::{task, TaskRequest};
+use std::collections::HashMap;
 
 use clap::{Parser, Subcommand};
 
@@ -10,14 +12,53 @@ struct Args {
 
 #[derive(Subcommand, Clone)]
 enum Command {
-    Run { cmdline: Vec<String> },
+    Run {
+        cmdline: Vec<String>,
+
+        #[arg(short = 'e', long = "env")]
+        environment: Vec<String>,
+    },
+}
+
+// Parse a list of arguments given to the -e flag, and returns a map from key to value:
+// - If the argument has the form KEY=VALUE, then (KEY, VALUE) is used
+// - If the argument has the form KEY and KEY exists in the current process' environment, that
+//   value is used
+// - If the arguments has the form KEY and KEY does not exist in the process' environment, the
+//   argument is ignored
+//
+// This is the same behaviour used by the `docker run` command.
+fn parse_environment(env: &[String]) -> anyhow::Result<HashMap<String, String>> {
+    env.iter()
+        .filter_map(|arg| {
+            if let Some((key, value)) = arg.split_once("=") {
+                Some(Ok((key.to_owned(), value.to_owned())))
+            } else {
+                use std::env::VarError::*;
+                match std::env::var(arg) {
+                    Ok(value) => Some(Ok((arg.to_owned(), value))),
+                    Err(NotPresent) => None,
+                    Err(NotUnicode(_)) => Some(Err(anyhow!(
+                        "Environment variable {} contains invalid characters",
+                        arg
+                    ))),
+                }
+            }
+        })
+        .collect()
 }
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     match args.cmd {
-        Command::Run { cmdline } => {
-            let result = task::execute(&TaskRequest { cmdline })?;
+        Command::Run {
+            cmdline,
+            environment,
+        } => {
+            let result = task::execute(&TaskRequest {
+                cmdline,
+                environment: parse_environment(&environment)?,
+            })?;
             for l in result.output {
                 println!("{}", l);
             }

--- a/api/src/task.rs
+++ b/api/src/task.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use anyhow::Context as _;
+use std::collections::HashMap;
 use std::io::Read;
 use std::process::{Command, ExitStatus};
 use tempdir::TempDir;
@@ -7,6 +8,7 @@ use tempdir::TempDir;
 #[derive(Debug)]
 pub struct TaskRequest {
     pub cmdline: Vec<String>,
+    pub environment: HashMap<String, String>,
 }
 
 #[derive(Debug)]
@@ -25,6 +27,7 @@ pub fn execute(request: &TaskRequest) -> crate::Result<TaskResult> {
     let wd = TempDir::new("task")?;
     let mut child = Command::new(&request.cmdline[0])
         .args(&request.cmdline[1..])
+        .envs(&request.environment)
         .current_dir(&wd)
         .stdout(send.try_clone()?)
         .stderr(send)
@@ -62,6 +65,7 @@ mod tests {
     fn can_execute_task() -> anyhow::Result<()> {
         let result = execute(&TaskRequest {
             cmdline: vec![String::from("echo"), String::from("Hello")],
+            environment: HashMap::new(),
         })?;
         assert_eq!(result.status.code(), Some(0));
         assert_eq!(result.output, ["Hello"]);
@@ -72,6 +76,7 @@ mod tests {
     fn exit_code_is_reported() -> anyhow::Result<()> {
         let result = execute(&TaskRequest {
             cmdline: vec![String::from("false")],
+            environment: HashMap::new(),
         })?;
         assert_eq!(result.status.code(), Some(1));
         Ok(())
@@ -79,7 +84,10 @@ mod tests {
 
     #[test]
     fn cannot_run_empty_command() {
-        let result = execute(&TaskRequest { cmdline: vec![] });
+        let result = execute(&TaskRequest {
+            cmdline: vec![],
+            environment: HashMap::new(),
+        });
         assert_that!(result)
             .err()
             .has_message("Task command is empty");
@@ -89,10 +97,23 @@ mod tests {
     fn invalid_commands_are_caught() {
         let result = execute(&TaskRequest {
             cmdline: vec![String::from("not-a-real-command")],
+            environment: HashMap::new(),
         });
         assert_that!(result)
             .err()
             .as_string()
             .contains("Failed to start command");
+    }
+
+    #[test]
+    fn can_set_environment_variables() -> anyhow::Result<()> {
+        let result = execute(&TaskRequest {
+            cmdline: vec![String::from("env")],
+            environment: HashMap::from([(String::from("key"), String::from("value"))]),
+        })?;
+
+        assert_that!(result.output).contains(String::from("key=value"));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This uses `-e` / `--env` on the command line. One can either specify a `key=value` or just a `key`. In the latter case, the value is inherited from the calling environment. If the variable is missing from the environment nothing is passed. This mirrors the semantics of `docker run`.

Obviously in the case of the `run` command, the entire environment is inherited anyway (for now at least), but this will be more useful in the client-server case.