### PR TITLE
Add a database to track tasks.

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ff24d87260733dc86d38a11c60d9400ce4a74a05d0dafa2a6f5ab249cd857cb"
 dependencies = [
  "anyhow",
+ "num-traits",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
  "num-traits",
 ]
 
@@ -180,16 +195,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -259,6 +298,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +329,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +409,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -311,16 +452,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -369,6 +549,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +602,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -455,12 +667,59 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -747,12 +1006,32 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -765,6 +1044,16 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -785,6 +1074,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
+ "sqlx",
  "tempdir",
  "tokio",
  "tower-http",
@@ -807,6 +1097,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -868,12 +1168,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -948,6 +1286,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1342,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1018,6 +1424,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,12 +1460,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1151,6 +1596,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1687,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1301,6 +1772,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1809,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1829,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1338,10 +1844,232 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -1413,7 +2141,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand",
+ "rand 0.4.6",
  "remove_dir_all",
 ]
 
@@ -1428,6 +2156,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1448,6 +2196,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1493,6 +2256,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1625,10 +2399,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "untrusted"
@@ -1684,6 +2485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +2513,12 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1789,6 +2602,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,6 +2670,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -1870,6 +2702,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1906,6 +2753,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1918,6 +2771,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1927,6 +2786,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1954,6 +2819,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1963,6 +2834,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1978,6 +2855,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1987,6 +2870,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2037,6 +2926,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
  "shlex",
  "sqlx",
  "tempdir",
+ "thiserror",
  "tokio",
  "tower-http",
  "tracing",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -18,7 +18,7 @@ tokio = "1.45.1"
 tower-http = { version = "0.6.6", features = ["trace"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-uuid = { version = "1.17.0", features = ["serde", "v4"] }
+uuid = { version = "1.17.0", features = ["serde", "v7"] }
 
 [dev-dependencies]
 assertor = { version = "0.0.4", features = ["anyhow"] }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1.0.140"
 shlex = "1.3.0"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "uuid"] }
 tempdir = "0.3.7"
+thiserror = "2.0.12"
 tokio = "1.45.1"
 tower-http = { version = "0.6.6", features = ["trace"] }
 tracing = "0.1.41"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,6 +12,7 @@ reqwest = { version = "0.12.20", features = ["blocking", "json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 shlex = "1.3.0"
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "uuid"] }
 tempdir = "0.3.7"
 tokio = "1.45.1"
 tower-http = { version = "0.6.6", features = ["trace"] }

--- a/api/build.rs
+++ b/api/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // https://docs.rs/sqlx/0.8.6/sqlx/macro.migrate.html#triggering-recompilation-on-migration-changes
+    println!("cargo:rerun-if-changed=migrations");
+}

--- a/api/migrations/01_initial-schema.sql
+++ b/api/migrations/01_initial-schema.sql
@@ -1,0 +1,8 @@
+-- For now it is acceptable to modify this file. Once we start having
+-- real-world uses we should freeze its contents and only update the schema by
+-- writing new migrations.
+
+CREATE TABLE task(
+  `id` BLOB NOT NULL PRIMARY KEY CHECK(length(id) = 16),
+  `status` TEXT NOT NULL
+);

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -1,6 +1,8 @@
 use crate::messages::TaskSubmitResponse;
 use crate::responses::ResponseExt;
 use crate::{TaskInfo, TaskRequest};
+use anyhow::anyhow;
+use reqwest::StatusCode;
 use uuid::Uuid;
 
 pub struct Client {
@@ -32,7 +34,14 @@ impl Client {
             .client
             .get(self.base_url.join("tasks/")?.join(&id.to_string())?)
             .send()?
-            .api_response::<TaskInfo>()?;
+            .api_response::<TaskInfo>()
+            .map_err(|e| {
+                if e.has_status(StatusCode::NOT_FOUND) {
+                    anyhow!("Unknown task {id}")
+                } else {
+                    e.into()
+                }
+            })?;
 
         Ok(response)
     }

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -1,5 +1,6 @@
-use crate::messages::{ApiResponse, TaskSubmitResponse};
-use crate::TaskRequest;
+use crate::messages::TaskSubmitResponse;
+use crate::responses::ResponseExt;
+use crate::{TaskInfo, TaskRequest};
 use uuid::Uuid;
 
 pub struct Client {
@@ -15,17 +16,34 @@ impl Client {
         }
     }
 
-    pub fn submit(&self, request: &TaskRequest) -> crate::Result<Uuid> {
+    pub fn task_submit(&self, request: &TaskRequest) -> crate::Result<Uuid> {
         let response = self
             .client
-            .post(self.base_url.join("task")?)
+            .post(self.base_url.join("tasks")?)
             .json(request)
             .send()?
-            .error_for_status()?
-            .json::<ApiResponse<TaskSubmitResponse>>()?;
+            .api_response::<TaskSubmitResponse>()?;
 
-        let ApiResponse::Success { data } = response;
+        Ok(response.id)
+    }
 
-        Ok(data.id)
+    pub fn task_get(&self, id: Uuid) -> crate::Result<TaskInfo> {
+        let response = self
+            .client
+            .get(self.base_url.join("tasks/")?.join(&id.to_string())?)
+            .send()?
+            .api_response::<TaskInfo>()?;
+
+        Ok(response)
+    }
+
+    pub fn task_list(&self) -> crate::Result<Vec<TaskInfo>> {
+        let response = self
+            .client
+            .get(self.base_url.join("tasks")?)
+            .send()?
+            .api_response::<Vec<TaskInfo>>()?;
+
+        Ok(response)
     }
 }

--- a/api/src/database.rs
+++ b/api/src/database.rs
@@ -1,0 +1,139 @@
+use crate::task::{TaskInfo, TaskStatus};
+use anyhow::bail;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct Database {
+    pool: SqlitePool,
+}
+
+impl Database {
+    pub async fn open_in_memory() -> crate::Result<Database> {
+        let pool = SqlitePool::connect("sqlite::memory:").await?;
+        sqlx::migrate!("./migrations").run(&pool).await?;
+        Ok(Database { pool })
+    }
+
+    pub async fn task_create(&self) -> crate::Result<Uuid> {
+        let id = Uuid::new_v4();
+        sqlx::query("INSERT INTO task (id, status) VALUES ($1, $2)")
+            .bind(id)
+            .bind(TaskStatus::Pending)
+            .execute(&self.pool)
+            .await?;
+        Ok(id)
+    }
+
+    pub async fn task_get_status(&self, id: Uuid) -> crate::Result<Option<TaskInfo>> {
+        let task = sqlx::query_as::<_, TaskInfo>("SELECT id, status FROM task WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(task)
+    }
+
+    pub async fn task_list(&self) -> crate::Result<Vec<TaskInfo>> {
+        let tasks = sqlx::query_as::<_, TaskInfo>("SELECT id, status FROM task")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(tasks)
+    }
+
+    pub async fn task_update(&self, id: Uuid, status: TaskStatus) -> crate::Result<()> {
+        tracing::debug!(task = %id, ?status, "updating task status");
+        let result = sqlx::query("UPDATE task SET status = $1 WHERE id = $2")
+            .bind(status)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        if result.rows_affected() == 0 {
+            bail!("invalid task");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assertor::*;
+
+    #[tokio::test]
+    async fn can_create_database() {
+        assert_that!(Database::open_in_memory().await).is_ok();
+    }
+
+    #[tokio::test]
+    async fn can_create_task() -> anyhow::Result<()> {
+        let db = Database::open_in_memory().await?;
+        let id = db.task_create().await?;
+
+        let task = db.task_get_status(id).await?;
+        assert_that!(task).some().is_equal_to(TaskInfo {
+            id,
+            status: TaskStatus::Pending,
+        });
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn returns_none_on_missing_task() -> anyhow::Result<()> {
+        let db = Database::open_in_memory().await?;
+        let id = Uuid::new_v4();
+
+        assert_that!(db.task_get_status(id).await?).is_none();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_update_task_status() -> anyhow::Result<()> {
+        let db = Database::open_in_memory().await?;
+        let id = db.task_create().await?;
+
+        db.task_update(id, TaskStatus::Running).await?;
+
+        let task = db.task_get_status(id).await?;
+        assert_that!(task).some().is_equal_to(TaskInfo {
+            id,
+            status: TaskStatus::Running,
+        });
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn updating_invalid_task_fails() -> anyhow::Result<()> {
+        let db = Database::open_in_memory().await?;
+        let id = Uuid::new_v4();
+
+        let result = db.task_update(id, TaskStatus::Running).await;
+        assert_that!(result).err().has_message("invalid task");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_list_tasks() -> anyhow::Result<()> {
+        let db = Database::open_in_memory().await?;
+        let id1 = db.task_create().await?;
+        let id2 = db.task_create().await?;
+        db.task_update(id1, TaskStatus::Running).await?;
+
+        let tasks = db.task_list().await?;
+        assert_that!(tasks).contains_exactly(vec![
+            TaskInfo {
+                id: id1,
+                status: TaskStatus::Running,
+            },
+            TaskInfo {
+                id: id2,
+                status: TaskStatus::Pending,
+            },
+        ]);
+
+        Ok(())
+    }
+}

--- a/api/src/database.rs
+++ b/api/src/database.rs
@@ -16,7 +16,7 @@ impl Database {
     }
 
     pub async fn task_create(&self) -> crate::Result<Uuid> {
-        let id = Uuid::new_v4();
+        let id = Uuid::now_v7();
         sqlx::query("INSERT INTO task (id, status) VALUES ($1, $2)")
             .bind(id)
             .bind(TaskStatus::Pending)
@@ -81,7 +81,7 @@ mod tests {
     #[tokio::test]
     async fn returns_none_on_missing_task() -> anyhow::Result<()> {
         let db = Database::open_in_memory().await?;
-        let id = Uuid::new_v4();
+        let id = Uuid::now_v7();
 
         assert_that!(db.task_get_status(id).await?).is_none();
 
@@ -107,7 +107,7 @@ mod tests {
     #[tokio::test]
     async fn updating_invalid_task_fails() -> anyhow::Result<()> {
         let db = Database::open_in_memory().await?;
-        let id = Uuid::new_v4();
+        let id = Uuid::now_v7();
 
         let result = db.task_update(id, TaskStatus::Running).await;
         assert_that!(result).err().has_message("invalid task");

--- a/api/src/execute.rs
+++ b/api/src/execute.rs
@@ -1,0 +1,122 @@
+use anyhow::bail;
+use anyhow::Context as _;
+use std::io::Read;
+use std::process::Command;
+use tempdir::TempDir;
+use tracing::info;
+
+use crate::task::{TaskRequest, TaskResult};
+
+#[tracing::instrument(level = "info", skip_all, err(level = "info"))]
+pub fn execute(request: &TaskRequest) -> crate::Result<TaskResult> {
+    info!("executing command {:?}", request.cmdline);
+
+    if request.cmdline.is_empty() {
+        bail!("Task command is empty")
+    }
+
+    let (mut recv, send) = std::io::pipe()?;
+
+    let wd = TempDir::new("task")?;
+    let mut child = Command::new(&request.cmdline[0])
+        .args(&request.cmdline[1..])
+        .envs(&request.environment)
+        .current_dir(&wd)
+        .stdout(send.try_clone()?)
+        .stderr(send)
+        .spawn()
+        .with_context(|| {
+            format!(
+                "Failed to start command: {}",
+                shlex::try_join(request.cmdline.iter().map(AsRef::as_ref))
+                    .expect("command has nul byte")
+            )
+        })?;
+
+    let mut output = Vec::new();
+    recv.read_to_end(&mut output)?;
+
+    let status = child.wait()?;
+
+    cfg_if::cfg_if! {
+        if #[cfg(unix)] {
+            use std::os::unix::process::ExitStatusExt;
+            info!(code = status.code(), signal = status.signal(), "command completed");
+        } else {
+            info!(code = status.code(), "command completed");
+        }
+    }
+
+    Ok(TaskResult {
+        status,
+        output: String::from_utf8_lossy(&output)
+            .lines()
+            .map(String::from)
+            .collect(),
+    })
+}
+
+// These tests do make some basic assumptions about the command line tools available on the system.
+// They will work on Linux and macOS, but maybe not on all Windows installations.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assertor::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn can_execute_task() -> anyhow::Result<()> {
+        let result = execute(&TaskRequest {
+            cmdline: vec![String::from("echo"), String::from("Hello")],
+            environment: HashMap::new(),
+        })?;
+        assert_eq!(result.status.code(), Some(0));
+        assert_eq!(result.output, ["Hello"]);
+        Ok(())
+    }
+
+    #[test]
+    fn exit_code_is_reported() -> anyhow::Result<()> {
+        let result = execute(&TaskRequest {
+            cmdline: vec![String::from("false")],
+            environment: HashMap::new(),
+        })?;
+        assert_eq!(result.status.code(), Some(1));
+        Ok(())
+    }
+
+    #[test]
+    fn cannot_run_empty_command() {
+        let result = execute(&TaskRequest {
+            cmdline: vec![],
+            environment: HashMap::new(),
+        });
+        assert_that!(result)
+            .err()
+            .has_message("Task command is empty");
+    }
+
+    #[test]
+    fn invalid_commands_are_caught() {
+        let result = execute(&TaskRequest {
+            cmdline: vec![String::from("not-a-real-command")],
+            environment: HashMap::new(),
+        });
+        assert_that!(result)
+            .err()
+            .as_string()
+            .contains("Failed to start command");
+    }
+
+    #[test]
+    fn can_set_environment_variables() -> anyhow::Result<()> {
+        let result = execute(&TaskRequest {
+            cmdline: vec![String::from("env")],
+            environment: HashMap::from([(String::from("key"), String::from("value"))]),
+        })?;
+
+        assert_that!(result.output).contains(String::from("key=value"));
+
+        Ok(())
+    }
+}

--- a/api/src/execute.rs
+++ b/api/src/execute.rs
@@ -11,15 +11,15 @@ use crate::task::{TaskRequest, TaskResult};
 pub fn execute(request: &TaskRequest) -> crate::Result<TaskResult> {
     info!("executing command {:?}", request.cmdline);
 
-    if request.cmdline.is_empty() {
+    let Some((program, args)) = request.cmdline.split_first() else {
         bail!("Task command is empty")
-    }
+    };
 
     let (mut recv, send) = std::io::pipe()?;
 
     let wd = TempDir::new("task")?;
-    let mut child = Command::new(&request.cmdline[0])
-        .args(&request.cmdline[1..])
+    let mut child = Command::new(program)
+        .args(args)
         .envs(&request.environment)
         .current_dir(&wd)
         .stdout(send.try_clone()?)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,6 +1,9 @@
 mod client;
+mod database;
 mod error;
+mod execute;
 mod messages;
+mod responses;
 pub mod server;
 pub mod task;
 
@@ -8,5 +11,8 @@ pub mod task;
 mod tests;
 
 pub use crate::client::Client;
+use crate::database::Database;
 pub use crate::error::{Error, Result};
+pub use crate::execute::execute;
+pub use crate::task::TaskInfo;
 pub use crate::task::TaskRequest;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> anyhow::Result<()> {
                 environment,
             })?;
             for l in result.output {
-                println!("{}", l);
+                println!("{l}");
             }
             println!("Task terminated with {}", result.status);
         }
@@ -105,7 +105,7 @@ fn main() -> anyhow::Result<()> {
                 cmdline,
                 environment,
             })?;
-            println!("Task submitted as {}", id);
+            println!("Task submitted as {id}");
         }
 
         Command::Task(TaskCommand::Status { server, id }) => {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::bail;
-use marathon_api::{server, task, Client, TaskRequest};
+use marathon_api::{execute, server, Client, TaskRequest};
 use std::collections::HashMap;
 
 use clap::{Parser, Subcommand};
@@ -12,7 +12,7 @@ struct Args {
 }
 
 #[derive(Subcommand, Clone)]
-enum Command {
+enum TaskCommand {
     Run {
         #[arg(short = 'e', long = "env")]
         environment: Vec<String>,
@@ -25,10 +25,21 @@ enum Command {
         environment: Vec<String>,
         cmdline: Vec<String>,
     },
+    Status {
+        #[arg(long)]
+        server: reqwest::Url,
+        id: Option<uuid::Uuid>,
+    },
+}
+
+#[derive(Subcommand, Clone)]
+enum Command {
     Server {
         #[arg(long, default_value = "0.0.0.0:8000")]
         listen: SocketAddr,
     },
+    #[command(subcommand)]
+    Task(TaskCommand),
 }
 
 // Parse an argument given to the -e flag, and returns an optional key-value pair:
@@ -68,12 +79,12 @@ where
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     match args.cmd {
-        Command::Run {
+        Command::Task(TaskCommand::Run {
             cmdline,
             environment,
-        } => {
+        }) => {
             let environment = parse_environment(&environment, |k| std::env::var(k))?;
-            let result = task::execute(&TaskRequest {
+            let result = execute(&TaskRequest {
                 cmdline,
                 environment,
             })?;
@@ -82,21 +93,35 @@ fn main() -> anyhow::Result<()> {
             }
             println!("Task terminated with {}", result.status);
         }
-        Command::Submit {
+
+        Command::Task(TaskCommand::Submit {
             server,
             cmdline,
             environment,
-        } => {
+        }) => {
             let environment = parse_environment(&environment, |k| std::env::var(k))?;
             let client = Client::new(server);
-            let id = client.submit(&TaskRequest {
+            let id = client.task_submit(&TaskRequest {
                 cmdline,
                 environment,
             })?;
             println!("Task submitted as {}", id);
         }
+
+        Command::Task(TaskCommand::Status { server, id }) => {
+            let client = Client::new(server);
+            if let Some(id) = id {
+                let task = client.task_get(id)?;
+                println!("Task status: {:?}", task.status);
+            } else {
+                for task in client.task_list()? {
+                    println!("{}: {:?}", task.id, task.status);
+                }
+            }
+        }
+
         Command::Server { listen } => {
-            server::start(&listen);
+            server::start(&listen)?;
         }
     }
     Ok(())

--- a/api/src/messages.rs
+++ b/api/src/messages.rs
@@ -1,26 +1,5 @@
-use axum::body::Body;
-use axum::http::Response;
-use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-
-#[derive(Serialize, Deserialize)]
-#[serde(tag = "status")]
-pub enum ApiResponse<T> {
-    #[serde(rename = "success")]
-    Success { data: T },
-}
-impl<T> ApiResponse<T> {
-    pub fn success(data: T) -> ApiResponse<T> {
-        ApiResponse::Success { data }
-    }
-}
-
-impl<T: Serialize> IntoResponse for ApiResponse<T> {
-    fn into_response(self) -> Response<Body> {
-        axum::Json(self).into_response()
-    }
-}
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct TaskSubmitResponse {

--- a/api/src/responses.rs
+++ b/api/src/responses.rs
@@ -1,0 +1,159 @@
+//! This module provides the basic scaffolding used to encode responses from the API.
+//!
+//! The types in this module and the schema of the responses are generic and could be used in other
+//! API implementations.
+
+use anyhow::bail;
+use axum::body::Body;
+use axum::http::{Response, StatusCode};
+use axum::response::IntoResponse;
+use reqwest::header::CONTENT_TYPE;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "status", rename = "success")]
+pub struct ApiSuccess<T> {
+    pub data: T,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "status", rename = "failure")]
+pub struct ApiFailure {
+    pub errors: Vec<ApiError>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ApiError {
+    pub error: String,
+    pub detail: Option<String>,
+}
+
+/// The return type for Axum endpoint handlers.
+///
+/// `ApiResponse` values can either be created explicitly using functions such as
+/// `ApiResponse::ok(...)` or `ApiResponse::not_found()`, or they can be created by propagating an
+/// arbitrary error using the try `?` operator. Propagated errors are always considered unexpected
+/// and are mapped to a 500 status code.
+///
+/// This needs to be a `Result` in order for the Try operator to work. If and when the
+/// `FromResidual` trait is stabilised this can become its own struct or enum type, which will make
+/// defining methods on it more straightforward.
+pub type ApiResponse<T> = Result<ApiSuccessResponse<T>, ApiFailureResponse>;
+
+pub struct ApiSuccessResponse<T> {
+    body: ApiSuccess<T>,
+    status: StatusCode,
+}
+
+pub struct ApiFailureResponse {
+    body: ApiFailure,
+    status: StatusCode,
+}
+
+impl<T: Serialize> IntoResponse for ApiSuccessResponse<T> {
+    fn into_response(self) -> Response<Body> {
+        let mut response = axum::Json(&self.body).into_response();
+        *response.status_mut() = self.status;
+        response
+    }
+}
+
+impl IntoResponse for ApiFailureResponse {
+    fn into_response(self) -> Response<Body> {
+        let mut response = axum::Json(&self.body).into_response();
+        *response.status_mut() = self.status;
+        response
+    }
+}
+
+/// This trait provides extension methods on the `ApiResponse` type.
+pub trait ApiResponseExt<T> {
+    /// Return a 200 OK response
+    ///
+    /// Result already has an `ok` method which would clash, hence the alternative name.
+    fn success(data: T) -> Self;
+
+    /// Return a 204 Created response
+    fn created(data: T) -> Self;
+
+    /// Return a 404 Not Found error
+    fn not_found() -> Self;
+}
+impl<T> ApiResponseExt<T> for ApiResponse<T> {
+    fn success(data: T) -> Self {
+        Ok(ApiSuccessResponse {
+            body: ApiSuccess { data },
+            status: StatusCode::OK,
+        })
+    }
+
+    fn created(data: T) -> Self {
+        Ok(ApiSuccessResponse {
+            body: ApiSuccess { data },
+            status: StatusCode::CREATED,
+        })
+    }
+
+    fn not_found() -> Self {
+        Err(ApiFailureResponse {
+            body: ApiFailure {
+                errors: vec![ApiError {
+                    error: "NOT_FOUND".to_owned(),
+                    detail: None,
+                }],
+            },
+            status: StatusCode::NOT_FOUND,
+        })
+    }
+}
+
+/// This trait implementation allows any error to be converted to an ApiResponse.
+///
+/// This is always considered an unhandled server error. Expected error should be created via
+/// methods on ApiResponse.
+impl<E: std::fmt::Display> From<E> for ApiFailureResponse {
+    fn from(error: E) -> ApiFailureResponse {
+        ApiFailureResponse {
+            body: ApiFailure {
+                errors: vec![ApiError {
+                    error: "INTERNAL_SERVER_ERROR".to_owned(),
+                    detail: Some(error.to_string()),
+                }],
+            },
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+/// Extension trait for reqwest's response type.
+pub trait ResponseExt {
+    /// Decode a response from the API and return its body.
+    ///
+    /// The top-level wrapper object is unpeeled and only the useful contents are returned. HTTP
+    /// errors are decoded and returned as an `Err`.
+    fn api_response<T: DeserializeOwned>(self) -> crate::Result<T>;
+}
+impl ResponseExt for reqwest::blocking::Response {
+    fn api_response<T: DeserializeOwned>(self) -> crate::Result<T> {
+        let code = self.status();
+
+        if code.is_client_error() || code.is_server_error() {
+            let content_type = self.headers().get(CONTENT_TYPE);
+            let url = self.url().clone();
+            if content_type.is_some_and(|v| v == "application/json") {
+                let body = self.json::<ApiFailure>()?;
+                if let Some(detail) = body.errors.first().and_then(|e| e.detail.as_ref()) {
+                    bail!("API error {} for url {}: {}", code, url, detail);
+                } else {
+                    bail!("API error {} for url {}", code, url);
+                }
+            } else {
+                bail!("HTTP status error {} for url {}", code, url);
+            }
+        }
+
+        let body = self.json::<ApiSuccess<T>>()?;
+        Ok(body.data)
+    }
+}

--- a/api/src/responses.rs
+++ b/api/src/responses.rs
@@ -3,7 +3,6 @@
 //! The types in this module and the schema of the responses are generic and could be used in other
 //! API implementations.
 
-use anyhow::bail;
 use axum::body::Body;
 use axum::http::{Response, StatusCode};
 use axum::response::IntoResponse;
@@ -79,6 +78,9 @@ pub trait ApiResponseExt<T> {
 
     /// Return a 404 Not Found error
     fn not_found() -> Self;
+
+    /// Return a 400 Bad Request error
+    fn bad_request() -> Self;
 }
 impl<T> ApiResponseExt<T> for ApiResponse<T> {
     fn success(data: T) -> Self {
@@ -106,6 +108,18 @@ impl<T> ApiResponseExt<T> for ApiResponse<T> {
             status: StatusCode::NOT_FOUND,
         })
     }
+
+    fn bad_request() -> Self {
+        Err(ApiFailureResponse {
+            body: ApiFailure {
+                errors: vec![ApiError {
+                    error: "BAD_REQUEST".to_owned(),
+                    detail: None,
+                }],
+            },
+            status: StatusCode::BAD_REQUEST,
+        })
+    }
 }
 
 /// This trait implementation allows any error to be converted to an ApiResponse.
@@ -126,30 +140,74 @@ impl<E: std::fmt::Display> From<E> for ApiFailureResponse {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum ApiClientError {
+    HTTPError {
+        status: StatusCode,
+        url: reqwest::Url,
+        body: Option<ApiFailure>,
+    },
+    Other(#[from] reqwest::Error),
+}
+
+impl ApiClientError {
+    pub fn has_status(&self, expected: StatusCode) -> bool {
+        match self {
+            ApiClientError::HTTPError { status, .. } => *status == expected,
+            ApiClientError::Other(inner) => {
+                // The reqwest::Error in the Other variant is used for for I/O and deserialization
+                // errors, not for error HTTP status codes.
+                assert!(inner.status().is_none());
+                false
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ApiClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiClientError::Other(e) => e.fmt(f),
+            ApiClientError::HTTPError { status, url, body } => {
+                if let Some(detail) = body
+                    .as_ref()
+                    .and_then(|b| b.errors.first())
+                    .and_then(|e| e.detail.as_ref())
+                {
+                    write!(f, "API error {status} for url {url}: {detail}")
+                } else {
+                    write!(f, "API error {status} for url {url}")
+                }
+            }
+        }
+    }
+}
+
 /// Extension trait for reqwest's response type.
 pub trait ResponseExt {
     /// Decode a response from the API and return its body.
     ///
     /// The top-level wrapper object is unpeeled and only the useful contents are returned. HTTP
     /// errors are decoded and returned as an `Err`.
-    fn api_response<T: DeserializeOwned>(self) -> crate::Result<T>;
+    fn api_response<T: DeserializeOwned>(self) -> Result<T, ApiClientError>;
 }
 impl ResponseExt for reqwest::blocking::Response {
-    fn api_response<T: DeserializeOwned>(self) -> crate::Result<T> {
-        let code = self.status();
+    fn api_response<T: DeserializeOwned>(self) -> Result<T, ApiClientError> {
+        let status = self.status();
 
-        if code.is_client_error() || code.is_server_error() {
+        if status.is_client_error() || status.is_server_error() {
             let content_type = self.headers().get(CONTENT_TYPE);
             let url = self.url().clone();
             if content_type.is_some_and(|v| v == "application/json") {
-                let body = self.json::<ApiFailure>()?;
-                if let Some(detail) = body.errors.first().and_then(|e| e.detail.as_ref()) {
-                    bail!("API error {} for url {}: {}", code, url, detail);
-                } else {
-                    bail!("API error {} for url {}", code, url);
-                }
+                // We ignore errors decoding the body. If there are any we just use None.
+                let body = self.json::<ApiFailure>().ok();
+                return Err(ApiClientError::HTTPError { status, url, body });
             } else {
-                bail!("HTTP status error {} for url {}", code, url);
+                return Err(ApiClientError::HTTPError {
+                    status,
+                    url,
+                    body: None,
+                });
             }
         }
 

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,40 +1,115 @@
-use crate::messages::{ApiResponse, TaskSubmitResponse};
-use crate::{task, TaskRequest};
-use axum::{routing::post, Json, Router};
+use crate::messages::TaskSubmitResponse;
+use crate::responses::{ApiResponse, ApiResponseExt};
+use crate::task::{TaskResult, TaskStatus};
+use crate::{execute, Database, TaskInfo, TaskRequest};
+use axum::extract::{Path, State};
+use axum::{routing::get, Json, Router};
 use std::net::SocketAddr;
 use tower_http::trace::TraceLayer;
 use uuid::Uuid;
 
-async fn task_submit(Json(request): Json<TaskRequest>) -> ApiResponse<TaskSubmitResponse> {
-    // Eventually this should add to a queue, rather than run immediately. There is no way to check
-    // the result of the task based on the ID. In the future the client will use a separate
-    // endpoint to query the status.
-    let id = Uuid::new_v4();
-
-    std::thread::spawn(move || {
-        tracing::info_span!("task", id = %id).in_scope(move || {
-            // Ignore errors. Not much we can do and task::execute already does enough logging.
-            let _ = task::execute(&request);
-        });
-    });
-
-    ApiResponse::success(TaskSubmitResponse { id })
+#[derive(Clone)]
+struct AppState {
+    database: Database,
 }
 
-pub fn create_app() -> Router<()> {
-    Router::new()
-        .route("/task", post(task_submit))
-        .layer(TraceLayer::new_for_http())
+/// This runs a marathon task in a background thread.
+///
+/// Eventually this will go away and be replaced by workers and a queue.
+fn execute_thread(
+    database: Database,
+    handle: tokio::runtime::Handle,
+    id: Uuid,
+    request: TaskRequest,
+) -> crate::Result<()> {
+    let _guard = tracing::info_span!("task", id = %id).entered();
+
+    handle.block_on(database.task_update(id, TaskStatus::Running))?;
+
+    let status = match execute(&request) {
+        Ok(TaskResult { status, .. }) => {
+            if status.success() {
+                TaskStatus::Complete
+            } else {
+                TaskStatus::Failed
+            }
+        }
+        Err(_) => TaskStatus::Failed,
+    };
+
+    handle.block_on(database.task_update(id, status))?;
+
+    Ok(())
+}
+
+async fn task_submit(
+    State(state): State<AppState>,
+    Json(request): Json<TaskRequest>,
+) -> ApiResponse<TaskSubmitResponse> {
+    let id = state.database.task_create().await?;
+
+    // We need the handle to do database updates from the background thread.
+    let handle = tokio::runtime::Handle::current();
+
+    // Eventually this should add to a queue, rather than run immediately.
+    std::thread::spawn(move || {
+        if let Err(error) = execute_thread(state.database, handle, id, request) {
+            // Not a lot more we can do about it at this point. This only concerns unexpected
+            // errors (eg. updating the database). Errors caused by the actual task are caught and
+            // recorded in the database.
+            tracing::error!(%error, "error while processing task");
+        }
+    });
+
+    ApiResponse::created(TaskSubmitResponse { id })
+}
+
+async fn task_get(Path(id): Path<Uuid>, State(state): State<AppState>) -> ApiResponse<TaskInfo> {
+    if let Some(task) = state.database.task_get_status(id).await? {
+        ApiResponse::success(task)
+    } else {
+        ApiResponse::not_found()
+    }
+}
+
+async fn task_list(State(state): State<AppState>) -> ApiResponse<Vec<TaskInfo>> {
+    let tasks = state.database.task_list().await?;
+    ApiResponse::success(tasks)
+}
+
+async fn index() -> ApiResponse<()> {
+    ApiResponse::success(())
+}
+
+async fn fallback_handler() -> ApiResponse<()> {
+    ApiResponse::not_found()
+}
+
+pub async fn create_app() -> crate::Result<Router<()>> {
+    let state = AppState {
+        database: Database::open_in_memory().await.unwrap(),
+    };
+
+    Ok(Router::new()
+        .route("/", get(index))
+        .route("/tasks", get(task_list).post(task_submit))
+        .route("/tasks/{id}", get(task_get))
+        .fallback(fallback_handler)
+        .with_state(state)
+        .layer(TraceLayer::new_for_http()))
 }
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn start(address: &SocketAddr) {
+pub async fn start(address: &SocketAddr) -> crate::Result<()> {
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::TRACE)
         .init();
 
-    let app = create_app();
-    let listener = tokio::net::TcpListener::bind(address).await.unwrap();
-    println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    let app = create_app().await?;
+
+    let listener = tokio::net::TcpListener::bind(address).await?;
+    println!("listening on {}", listener.local_addr()?);
+    axum::serve(listener, app).await?;
+
+    Ok(())
 }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -82,7 +82,7 @@ async fn index() -> ApiResponse<()> {
 }
 
 async fn fallback_handler() -> ApiResponse<()> {
-    ApiResponse::not_found()
+    ApiResponse::bad_request()
 }
 
 pub async fn create_app() -> crate::Result<Router<()>> {

--- a/api/src/task.rs
+++ b/api/src/task.rs
@@ -1,11 +1,7 @@
-use anyhow::bail;
-use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io::Read;
-use std::process::{Command, ExitStatus};
-use tempdir::TempDir;
-use tracing::info;
+use std::process::ExitStatus;
+use uuid::Uuid;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct TaskRequest {
@@ -19,115 +15,30 @@ pub struct TaskResult {
     pub output: Vec<String>,
 }
 
-#[tracing::instrument(level = "info", skip_all, err(level = "info"))]
-pub fn execute(request: &TaskRequest) -> crate::Result<TaskResult> {
-    info!("executing command {:?}", request.cmdline);
-
-    if request.cmdline.is_empty() {
-        bail!("Task command is empty")
-    }
-
-    let (mut recv, send) = std::io::pipe()?;
-
-    let wd = TempDir::new("task")?;
-    let mut child = Command::new(&request.cmdline[0])
-        .args(&request.cmdline[1..])
-        .envs(&request.environment)
-        .current_dir(&wd)
-        .stdout(send.try_clone()?)
-        .stderr(send)
-        .spawn()
-        .with_context(|| {
-            format!(
-                "Failed to start command: {}",
-                shlex::try_join(request.cmdline.iter().map(AsRef::as_ref))
-                    .expect("command has nul byte")
-            )
-        })?;
-
-    let mut output = Vec::new();
-    recv.read_to_end(&mut output)?;
-
-    let status = child.wait()?;
-
-    cfg_if::cfg_if! {
-        if #[cfg(unix)] {
-            use std::os::unix::process::ExitStatusExt;
-            info!(code = status.code(), signal = status.signal(), "command completed");
-        } else {
-            info!(code = status.code(), "command completed");
-        }
-    }
-
-    Ok(TaskResult {
-        status,
-        output: String::from_utf8_lossy(&output)
-            .lines()
-            .map(String::from)
-            .collect(),
-    })
+#[derive(Debug, Serialize, Deserialize, PartialEq, sqlx::FromRow)]
+pub struct TaskInfo {
+    pub id: Uuid,
+    pub status: TaskStatus,
 }
 
-// These tests do make some basic assumptions about the command line tools available on the system.
-// They will work on Linux and macOS, but maybe not on all Windows installations.
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use assertor::*;
+/// The different states a task may be in.
+#[derive(Debug, Serialize, Deserialize, PartialEq, sqlx::Type)]
+#[sqlx(rename_all = "UPPERCASE")]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TaskStatus {
+    Pending,
+    Running,
+    Complete,
+    Failed,
+}
 
-    #[test]
-    fn can_execute_task() -> anyhow::Result<()> {
-        let result = execute(&TaskRequest {
-            cmdline: vec![String::from("echo"), String::from("Hello")],
-            environment: HashMap::new(),
-        })?;
-        assert_eq!(result.status.code(), Some(0));
-        assert_eq!(result.output, ["Hello"]);
-        Ok(())
-    }
-
-    #[test]
-    fn exit_code_is_reported() -> anyhow::Result<()> {
-        let result = execute(&TaskRequest {
-            cmdline: vec![String::from("false")],
-            environment: HashMap::new(),
-        })?;
-        assert_eq!(result.status.code(), Some(1));
-        Ok(())
-    }
-
-    #[test]
-    fn cannot_run_empty_command() {
-        let result = execute(&TaskRequest {
-            cmdline: vec![],
-            environment: HashMap::new(),
-        });
-        assert_that!(result)
-            .err()
-            .has_message("Task command is empty");
-    }
-
-    #[test]
-    fn invalid_commands_are_caught() {
-        let result = execute(&TaskRequest {
-            cmdline: vec![String::from("not-a-real-command")],
-            environment: HashMap::new(),
-        });
-        assert_that!(result)
-            .err()
-            .as_string()
-            .contains("Failed to start command");
-    }
-
-    #[test]
-    fn can_set_environment_variables() -> anyhow::Result<()> {
-        let result = execute(&TaskRequest {
-            cmdline: vec![String::from("env")],
-            environment: HashMap::from([(String::from("key"), String::from("value"))]),
-        })?;
-
-        assert_that!(result.output).contains(String::from("key=value"));
-
-        Ok(())
+impl TaskStatus {
+    /// Returns true if the task is finished and won't make any more progress.
+    pub fn is_finished(self) -> bool {
+        use TaskStatus::*;
+        match self {
+            Pending | Running => false,
+            Complete | Failed => true,
+        }
     }
 }

--- a/api/src/tests.rs
+++ b/api/src/tests.rs
@@ -1,7 +1,10 @@
-use crate::{server::create_app, Client, TaskRequest};
+use crate::task::{TaskInfo, TaskRequest, TaskStatus};
+use crate::{server::create_app, Client};
+use assertor::*;
 use reqwest::Url;
 use std::collections::HashMap;
 use std::future::IntoFuture;
+use std::time::{Duration, Instant};
 use tokio::net::TcpListener;
 use tokio::runtime;
 use tokio::sync::oneshot;
@@ -18,6 +21,8 @@ fn start() -> anyhow::Result<(Client, BackgroundRuntime)> {
         .enable_all()
         .build()?;
 
+    let app = rt.block_on(create_app())?;
+
     // Bind on a random port and then find out what port was used so we can create the client.
     let listener = rt.block_on(TcpListener::bind("127.0.0.1:0"))?;
     let addr = listener.local_addr()?;
@@ -28,13 +33,11 @@ fn start() -> anyhow::Result<(Client, BackgroundRuntime)> {
 
     std::thread::spawn(move || {
         rt.block_on(async {
-            let app = create_app();
             tokio::spawn(axum::serve(listener, app).into_future());
             // This will block until the sender is dropped, at which point we return, stop the
             // runtime and close the server.
-            rx.await
-        })
-        .unwrap();
+            let _ = rx.await;
+        });
     });
 
     let url = Url::parse(&format!("http://{addr}"))?;
@@ -42,16 +45,96 @@ fn start() -> anyhow::Result<(Client, BackgroundRuntime)> {
     Ok((client, BackgroundRuntime(tx)))
 }
 
+/// Block until the given function returns true.
+///
+/// This is useful in tests that need to wait for something to happen asynchronously.
+/// It will poll the function repeatedly until the condition is true or some timeout has elapsed.
+/// If the function returns an error that error is propagated without retries.
+fn wait_for<F>(f: F) -> anyhow::Result<()>
+where
+    F: Fn() -> anyhow::Result<bool>,
+{
+    // Nothing we test for should take a long time. 1 second is plenty of time.
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while Instant::now() < deadline {
+        if f()? {
+            return Ok(());
+        }
+    }
+    anyhow::bail!("timeout")
+}
+
 #[test]
 fn can_submit_task() -> anyhow::Result<()> {
     let (client, _rt) = start()?;
-    let id = client.submit(&TaskRequest {
+    let id = client.task_submit(&TaskRequest {
         environment: HashMap::new(),
-        cmdline: vec!["ls".to_owned()],
+        cmdline: vec!["true".to_owned()],
     })?;
 
-    // Not the most useful test but this is pretty much the only thing that is exposed for now.
-    assert_eq!(id.get_version(), Some(uuid::Version::Random));
+    wait_for(|| Ok(client.task_get(id)?.status.is_finished()))?;
+
+    assert_eq!(
+        client.task_get(id)?,
+        TaskInfo {
+            id,
+            status: TaskStatus::Complete
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn failed_tasks_have_appropriate_status() -> anyhow::Result<()> {
+    let (client, _rt) = start()?;
+    // These two commands fail in different ways: the first one has a non-zero exit code whereas
+    // the second one does not even start. We don't yet have any way of distinguishing between the
+    // two cases.
+    let id1 = client.task_submit(&TaskRequest {
+        environment: HashMap::new(),
+        cmdline: vec!["false".to_owned()],
+    })?;
+    let id2 = client.task_submit(&TaskRequest {
+        environment: HashMap::new(),
+        cmdline: vec!["not-a-real-command".to_owned()],
+    })?;
+
+    wait_for(|| Ok(client.task_get(id1)?.status.is_finished()))?;
+    wait_for(|| Ok(client.task_get(id2)?.status.is_finished()))?;
+
+    assert_eq!(client.task_get(id1)?.status, TaskStatus::Failed);
+    assert_eq!(client.task_get(id2)?.status, TaskStatus::Failed);
+
+    Ok(())
+}
+
+#[test]
+fn can_list_tasks() -> anyhow::Result<()> {
+    let (client, _rt) = start()?;
+    let id1 = client.task_submit(&TaskRequest {
+        environment: HashMap::new(),
+        cmdline: vec!["true".to_owned()],
+    })?;
+    let id2 = client.task_submit(&TaskRequest {
+        environment: HashMap::new(),
+        cmdline: vec!["false".to_owned()],
+    })?;
+
+    wait_for(|| Ok(client.task_get(id1)?.status.is_finished()))?;
+    wait_for(|| Ok(client.task_get(id2)?.status.is_finished()))?;
+
+    let tasks = client.task_list()?;
+    assert_that!(tasks).contains_exactly(vec![
+        TaskInfo {
+            id: id1,
+            status: TaskStatus::Complete,
+        },
+        TaskInfo {
+            id: id2,
+            status: TaskStatus::Failed,
+        },
+    ]);
 
     Ok(())
 }


### PR DESCRIPTION
The database has a single table, mapping a task to its status. Tasks are initially marked as Pending, get updated to Running, and then either Complete or Failed.

The database uses SQLite and is currently only kept in memory. Obviously we will need to persist that on disk instead. We will definitely keep using SQLite for local uses of marathon, but in server use cases we might end up adding support for PostgreSQL.

The server gains new endpoints for listing all tasks and for checking the status of a single task. The client has matching commands that interact with the server.

At the moment the client does not have any local database. Tasks run locally (with `marathon task run`) are not recorded anywhere. Similarly, tasks run remotely (with `marathon task submit`) are only tracked by the server, not locally. This will change in the future.