### PR TITLE
Introduce a work queue and separate worker processes.

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -436,6 +436,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1097,7 @@ dependencies = [
  "shlex",
  "sqlx",
  "tempdir",
+ "test-log",
  "thiserror",
  "tokio",
  "tower-http",
@@ -2157,6 +2179,28 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,9 +12,10 @@ reqwest = { version = "0.12.20", features = ["blocking", "json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 shlex = "1.3.0"
-sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "uuid"] }
+sqlx = { version = "0.8.6", features = ["json", "runtime-tokio", "sqlite", "uuid"] }
 tempdir = "0.3.7"
 thiserror = "2.0.12"
+test-log = { version = "0.2.18", features = ["trace"] }
 tokio = "1.45.1"
 tower-http = { version = "0.6.6", features = ["trace"] }
 tracing = "0.1.41"

--- a/api/migrations/01_initial-schema.sql
+++ b/api/migrations/01_initial-schema.sql
@@ -4,5 +4,12 @@
 
 CREATE TABLE task(
   `id` BLOB NOT NULL PRIMARY KEY CHECK(length(id) = 16),
+  `request` BLOB NOT NULL,
   `status` TEXT NOT NULL
+);
+
+CREATE TABLE task_queue(
+  `seq` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `task` BLOB CHECK(length(task) = 16) NOT NULL,
+  FOREIGN KEY(task) REFERENCES task(id)
 );

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -1,9 +1,11 @@
-use crate::messages::TaskSubmitResponse;
+use crate::messages::{
+    QueuePullResponse, QueuePullResponseInner, QueueUpdateRequest, TaskSubmitResponse,
+};
 use crate::responses::ResponseExt;
-use crate::{TaskInfo, TaskRequest};
+use crate::task::{TaskId, TaskInfo, TaskRequest, TaskStatus};
 use anyhow::anyhow;
 use reqwest::StatusCode;
-use uuid::Uuid;
+use std::time::Duration;
 
 pub struct Client {
     base_url: reqwest::Url,
@@ -18,7 +20,11 @@ impl Client {
         }
     }
 
-    pub fn task_submit(&self, request: &TaskRequest) -> crate::Result<Uuid> {
+    pub fn url(&self) -> &reqwest::Url {
+        &self.base_url
+    }
+
+    pub fn task_submit(&self, request: &TaskRequest) -> crate::Result<TaskId> {
         let response = self
             .client
             .post(self.base_url.join("tasks")?)
@@ -29,7 +35,7 @@ impl Client {
         Ok(response.id)
     }
 
-    pub fn task_get(&self, id: Uuid) -> crate::Result<TaskInfo> {
+    pub fn task_get(&self, id: TaskId) -> crate::Result<TaskInfo> {
         let response = self
             .client
             .get(self.base_url.join("tasks/")?.join(&id.to_string())?)
@@ -54,5 +60,34 @@ impl Client {
             .api_response::<Vec<TaskInfo>>()?;
 
         Ok(response)
+    }
+
+    /// Pull an item from the server's work queue.
+    pub fn queue_pull(&self) -> crate::Result<Result<QueuePullResponseInner, Option<Duration>>> {
+        let response = self.client.post(self.base_url.join("queue/pull")?).send()?;
+
+        let retry_after = response
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .cloned();
+
+        match response.api_response::<QueuePullResponse>()? {
+            Some(inner) => Ok(Ok(inner)),
+            None => {
+                let interval = retry_after
+                    .and_then(|v| v.to_str().ok().and_then(|i| i.parse::<u64>().ok()))
+                    .map(Duration::from_secs);
+                Ok(Err(interval))
+            }
+        }
+    }
+
+    pub fn queue_update(&self, task: TaskId, status: TaskStatus) -> crate::Result<()> {
+        self.client
+            .post(self.base_url.join("queue/task")?)
+            .json(&QueueUpdateRequest { task, status })
+            .send()?
+            .api_response::<()>()?;
+        Ok(())
     }
 }

--- a/api/src/database.rs
+++ b/api/src/database.rs
@@ -1,7 +1,7 @@
-use crate::task::{TaskInfo, TaskStatus};
+use crate::task::{TaskId, TaskInfo, TaskRequest, TaskStatus};
 use anyhow::bail;
+use sqlx::types::Json;
 use sqlx::SqlitePool;
-use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct Database {
@@ -15,22 +15,47 @@ impl Database {
         Ok(Database { pool })
     }
 
-    pub async fn task_create(&self) -> crate::Result<Uuid> {
-        let id = Uuid::now_v7();
-        sqlx::query("INSERT INTO task (id, status) VALUES ($1, $2)")
+    /// Create a new task and add it to the queue.
+    ///
+    /// The task request is serialized and stored in the database. The task's initial status will
+    /// be `Pending`. A new unique identifier is generated for this task and is returned.
+    pub async fn task_create(&self, req: &TaskRequest) -> crate::Result<TaskId> {
+        let id = TaskId::new();
+
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("INSERT INTO task (id, status, request) VALUES ($1, $2, jsonb($3))")
             .bind(id)
             .bind(TaskStatus::Pending)
-            .execute(&self.pool)
+            .bind(serde_json::to_string(req)?)
+            .execute(&mut *tx)
             .await?;
+
+        sqlx::query("INSERT INTO task_queue (task) VALUES ($1)")
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+
         Ok(id)
     }
 
-    pub async fn task_get_status(&self, id: Uuid) -> crate::Result<Option<TaskInfo>> {
+    pub async fn task_get_info(&self, id: TaskId) -> crate::Result<Option<TaskInfo>> {
         let task = sqlx::query_as::<_, TaskInfo>("SELECT id, status FROM task WHERE id = $1")
             .bind(id)
             .fetch_optional(&self.pool)
             .await?;
         Ok(task)
+    }
+
+    pub async fn task_get_request(&self, id: TaskId) -> crate::Result<TaskRequest> {
+        let Json(request): Json<TaskRequest> =
+            sqlx::query_scalar("SELECT json(request) FROM task WHERE id = $1")
+                .bind(id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(request)
     }
 
     pub async fn task_list(&self) -> crate::Result<Vec<TaskInfo>> {
@@ -40,7 +65,7 @@ impl Database {
         Ok(tasks)
     }
 
-    pub async fn task_update(&self, id: Uuid, status: TaskStatus) -> crate::Result<()> {
+    pub async fn task_update(&self, id: TaskId, status: TaskStatus) -> crate::Result<()> {
         tracing::debug!(task = %id, ?status, "updating task status");
         let result = sqlx::query("UPDATE task SET status = $1 WHERE id = $2")
             .bind(status)
@@ -52,12 +77,45 @@ impl Database {
         }
         Ok(())
     }
+
+    /// Remove the first task from the work queue and mark its status as "Claimed".
+    pub async fn queue_pop(&self) -> crate::Result<Option<TaskId>> {
+        tracing::debug!("pulling a task from the work queue");
+
+        let mut tx = self.pool.begin().await?;
+
+        let task = sqlx::query_scalar(
+            "DELETE FROM task_queue
+             WHERE seq = (SELECT seq FROM task_queue ORDER BY seq LIMIT 1)
+             RETURNING task",
+        )
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        sqlx::query("UPDATE task SET status = $1 WHERE id = $2")
+            .bind(TaskStatus::Claimed)
+            .bind(task)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+
+        Ok(task)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use assertor::*;
+    use std::collections::HashMap;
+
+    fn dummy_request() -> TaskRequest {
+        TaskRequest {
+            cmdline: vec!["hello".to_owned()],
+            environment: HashMap::new(),
+        }
+    }
 
     #[tokio::test]
     async fn can_create_database() {
@@ -67,9 +125,8 @@ mod tests {
     #[tokio::test]
     async fn can_create_task() -> anyhow::Result<()> {
         let db = Database::open_in_memory().await?;
-        let id = db.task_create().await?;
-
-        let task = db.task_get_status(id).await?;
+        let id = db.task_create(&dummy_request()).await?;
+        let task = db.task_get_info(id).await?;
         assert_that!(task).some().is_equal_to(TaskInfo {
             id,
             status: TaskStatus::Pending,
@@ -79,11 +136,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn can_pop_tasks_from_queue() -> anyhow::Result<()> {
+        let db = Database::open_in_memory().await?;
+
+        let mut ids = vec![];
+        ids.push(db.task_create(&dummy_request()).await?);
+        ids.push(db.task_create(&dummy_request()).await?);
+        ids.push(db.task_create(&dummy_request()).await?);
+
+        assert_that!(db.task_get_info(ids[0]).await?.map(|t| t.status))
+            .some()
+            .is_equal_to(TaskStatus::Pending);
+
+        let mut result = vec![];
+        result.push(db.queue_pop().await?);
+        result.push(db.queue_pop().await?);
+        result.push(db.queue_pop().await?);
+        result.push(db.queue_pop().await?);
+
+        assert_that!(db.task_get_info(ids[0]).await?.map(|t| t.status))
+            .some()
+            .is_equal_to(TaskStatus::Claimed);
+
+        assert_eq!(result[..3], ids.into_iter().map(Some).collect::<Vec<_>>());
+        assert_that!(result[3]).is_none();
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn returns_none_on_missing_task() -> anyhow::Result<()> {
         let db = Database::open_in_memory().await?;
-        let id = Uuid::now_v7();
+        let id = TaskId::new();
 
-        assert_that!(db.task_get_status(id).await?).is_none();
+        assert_that!(db.task_get_info(id).await?).is_none();
 
         Ok(())
     }
@@ -91,11 +177,11 @@ mod tests {
     #[tokio::test]
     async fn can_update_task_status() -> anyhow::Result<()> {
         let db = Database::open_in_memory().await?;
-        let id = db.task_create().await?;
+        let id = db.task_create(&dummy_request()).await?;
 
         db.task_update(id, TaskStatus::Running).await?;
 
-        let task = db.task_get_status(id).await?;
+        let task = db.task_get_info(id).await?;
         assert_that!(task).some().is_equal_to(TaskInfo {
             id,
             status: TaskStatus::Running,
@@ -107,7 +193,7 @@ mod tests {
     #[tokio::test]
     async fn updating_invalid_task_fails() -> anyhow::Result<()> {
         let db = Database::open_in_memory().await?;
-        let id = Uuid::now_v7();
+        let id = TaskId::new();
 
         let result = db.task_update(id, TaskStatus::Running).await;
         assert_that!(result).err().has_message("invalid task");
@@ -118,8 +204,8 @@ mod tests {
     #[tokio::test]
     async fn can_list_tasks() -> anyhow::Result<()> {
         let db = Database::open_in_memory().await?;
-        let id1 = db.task_create().await?;
-        let id2 = db.task_create().await?;
+        let id1 = db.task_create(&dummy_request()).await?;
+        let id2 = db.task_create(&dummy_request()).await?;
         db.task_update(id1, TaskStatus::Running).await?;
 
         let tasks = db.task_list().await?;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -6,6 +6,7 @@ mod messages;
 mod responses;
 pub mod server;
 pub mod task;
+pub mod worker;
 
 #[cfg(test)]
 mod tests;
@@ -14,5 +15,3 @@ pub use crate::client::Client;
 use crate::database::Database;
 pub use crate::error::{Error, Result};
 pub use crate::execute::execute;
-pub use crate::task::TaskInfo;
-pub use crate::task::TaskRequest;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,9 +1,9 @@
 use anyhow::bail;
-use marathon_api::{execute, server, Client, TaskRequest};
-use std::collections::HashMap;
-
 use clap::{Parser, Subcommand};
+use marathon_api::{execute, server, task::TaskId, task::TaskRequest, worker, Client};
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 struct Args {
@@ -28,7 +28,7 @@ enum TaskCommand {
     Status {
         #[arg(long)]
         server: reqwest::Url,
-        id: Option<uuid::Uuid>,
+        id: Option<TaskId>,
     },
 }
 
@@ -37,6 +37,14 @@ enum Command {
     Server {
         #[arg(long, default_value = "0.0.0.0:8000")]
         listen: SocketAddr,
+
+        /// Start a background worker thread to run tasks.
+        #[arg(long)]
+        start_worker: bool,
+    },
+    Worker {
+        #[arg(long)]
+        server: reqwest::Url,
     },
     #[command(subcommand)]
     Task(TaskCommand),
@@ -76,7 +84,47 @@ where
         .collect()
 }
 
+fn tracing_filter() -> EnvFilter {
+    // https://github.com/tokio-rs/tracing/issues/3022
+    if let Ok(filter) = std::env::var("RUST_LOG") {
+        EnvFilter::new(filter)
+    } else {
+        EnvFilter::try_new("marathon_api=trace,info")
+            .expect("hard-coded default directive should be valid")
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+#[tracing::instrument(name = "server", skip_all)]
+async fn start_server(addr: SocketAddr, start_worker: bool) -> anyhow::Result<()> {
+    let config = server::Configuration::default();
+    let server = server::ApiServer::new(config).await?;
+
+    let listener = server.listen(addr).await?;
+
+    // If a worker thread is requested we bind onto an additional address on a random port on
+    // localhost to make sure we can reach it. Using the original listener directly isn't super
+    // reliable or cross-platform (eg. when addr is `0.0.0.0`, we may not be able to use that to
+    // connect).
+    if start_worker {
+        let extra_listener = server.listen("127.0.0.1:0").await?;
+        let extra_addr = extra_listener.local_addr()?;
+        let url = reqwest::Url::parse(&format!("http://{extra_addr}"))?;
+        let _worker = worker::run_background(url);
+
+        tokio::try_join!(listener, extra_listener)?;
+    } else {
+        listener.await?;
+    }
+
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_filter())
+        .init();
+
     let args = Args::parse();
     match args.cmd {
         Command::Task(TaskCommand::Run {
@@ -120,8 +168,15 @@ fn main() -> anyhow::Result<()> {
             }
         }
 
-        Command::Server { listen } => {
-            server::start(&listen)?;
+        Command::Server {
+            listen,
+            start_worker,
+        } => {
+            start_server(listen, start_worker)?;
+        }
+
+        Command::Worker { server } => {
+            worker::run(server)?;
         }
     }
     Ok(())

--- a/api/src/messages.rs
+++ b/api/src/messages.rs
@@ -1,7 +1,21 @@
+use crate::task::{TaskId, TaskRequest, TaskStatus};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct TaskSubmitResponse {
-    pub id: Uuid,
+    pub id: TaskId,
 }
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct QueueUpdateRequest {
+    pub task: TaskId,
+    pub status: TaskStatus,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct QueuePullResponseInner {
+    pub task: TaskId,
+    pub request: TaskRequest,
+}
+
+pub type QueuePullResponse = Option<QueuePullResponseInner>;

--- a/api/src/responses.rs
+++ b/api/src/responses.rs
@@ -3,9 +3,8 @@
 //! The types in this module and the schema of the responses are generic and could be used in other
 //! API implementations.
 
-use axum::body::Body;
-use axum::http::{Response, StatusCode};
-use axum::response::IntoResponse;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, IntoResponseParts, Response};
 use reqwest::header::CONTENT_TYPE;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -35,34 +34,40 @@ pub struct ApiError {
 /// arbitrary error using the try `?` operator. Propagated errors are always considered unexpected
 /// and are mapped to a 500 status code.
 ///
+/// The type allows any `P: IntoResponseParts` type to be attached in order to customize what
+/// headers are returned to the client.
+///
 /// This needs to be a `Result` in order for the Try operator to work. If and when the
 /// `FromResidual` trait is stabilised this can become its own struct or enum type, which will make
 /// defining methods on it more straightforward.
-pub type ApiResponse<T> = Result<ApiSuccessResponse<T>, ApiFailureResponse>;
+pub type ApiResponse<T, P = ()> =
+    Result<ResponseWrapper<ApiSuccess<T>, P>, ResponseWrapper<ApiFailure, P>>;
 
-pub struct ApiSuccessResponse<T> {
-    body: ApiSuccess<T>,
+pub struct ResponseWrapper<B, P> {
+    body: B,
     status: StatusCode,
+    parts: P,
 }
 
-pub struct ApiFailureResponse {
-    body: ApiFailure,
-    status: StatusCode,
-}
-
-impl<T: Serialize> IntoResponse for ApiSuccessResponse<T> {
-    fn into_response(self) -> Response<Body> {
-        let mut response = axum::Json(&self.body).into_response();
-        *response.status_mut() = self.status;
-        response
+impl<B: Serialize, P: IntoResponseParts> IntoResponse for ResponseWrapper<B, P> {
+    fn into_response(self) -> Response {
+        (self.status, self.parts, axum::Json(self.body)).into_response()
     }
 }
 
-impl IntoResponse for ApiFailureResponse {
-    fn into_response(self) -> Response<Body> {
-        let mut response = axum::Json(&self.body).into_response();
-        *response.status_mut() = self.status;
-        response
+impl<B> ResponseWrapper<B, ()> {
+    fn with<P: IntoResponseParts>(self, parts: P) -> ResponseWrapper<B, P> {
+        let ResponseWrapper {
+            body,
+            status,
+            parts: (),
+        } = self;
+
+        ResponseWrapper {
+            body,
+            status,
+            parts,
+        }
     }
 }
 
@@ -81,24 +86,32 @@ pub trait ApiResponseExt<T> {
 
     /// Return a 400 Bad Request error
     fn bad_request() -> Self;
+
+    /// Attach headers or extensions to the response.
+    ///
+    /// Any value which implements `IntoResponseParts` can be used. In particular, this includes
+    /// arrays of header name and value pairs.
+    fn with<P: IntoResponseParts>(self, parts: P) -> ApiResponse<T, P>;
 }
 impl<T> ApiResponseExt<T> for ApiResponse<T> {
     fn success(data: T) -> Self {
-        Ok(ApiSuccessResponse {
+        Ok(ResponseWrapper {
             body: ApiSuccess { data },
             status: StatusCode::OK,
+            parts: (),
         })
     }
 
     fn created(data: T) -> Self {
-        Ok(ApiSuccessResponse {
+        Ok(ResponseWrapper {
             body: ApiSuccess { data },
             status: StatusCode::CREATED,
+            parts: (),
         })
     }
 
     fn not_found() -> Self {
-        Err(ApiFailureResponse {
+        Err(ResponseWrapper {
             body: ApiFailure {
                 errors: vec![ApiError {
                     error: "NOT_FOUND".to_owned(),
@@ -106,11 +119,12 @@ impl<T> ApiResponseExt<T> for ApiResponse<T> {
                 }],
             },
             status: StatusCode::NOT_FOUND,
+            parts: (),
         })
     }
 
     fn bad_request() -> Self {
-        Err(ApiFailureResponse {
+        Err(ResponseWrapper {
             body: ApiFailure {
                 errors: vec![ApiError {
                     error: "BAD_REQUEST".to_owned(),
@@ -118,7 +132,15 @@ impl<T> ApiResponseExt<T> for ApiResponse<T> {
                 }],
             },
             status: StatusCode::BAD_REQUEST,
+            parts: (),
         })
+    }
+
+    fn with<P: IntoResponseParts>(self, parts: P) -> ApiResponse<T, P> {
+        match self {
+            Ok(inner) => Ok(inner.with(parts)),
+            Err(inner) => Err(inner.with(parts)),
+        }
     }
 }
 
@@ -126,9 +148,12 @@ impl<T> ApiResponseExt<T> for ApiResponse<T> {
 ///
 /// This is always considered an unhandled server error. Expected error should be created via
 /// methods on ApiResponse.
-impl<E: std::fmt::Display> From<E> for ApiFailureResponse {
-    fn from(error: E) -> ApiFailureResponse {
-        ApiFailureResponse {
+impl<E: std::fmt::Display, P> From<E> for ResponseWrapper<ApiFailure, P>
+where
+    P: Default + IntoResponseParts,
+{
+    fn from(error: E) -> ResponseWrapper<ApiFailure, P> {
+        ResponseWrapper {
             body: ApiFailure {
                 errors: vec![ApiError {
                     error: "INTERNAL_SERVER_ERROR".to_owned(),
@@ -136,6 +161,7 @@ impl<E: std::fmt::Display> From<E> for ApiFailureResponse {
                 }],
             },
             status: StatusCode::INTERNAL_SERVER_ERROR,
+            parts: P::default(),
         }
     }
 }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,71 +1,50 @@
-use crate::messages::TaskSubmitResponse;
+use crate::messages::{
+    QueuePullResponse, QueuePullResponseInner, QueueUpdateRequest, TaskSubmitResponse,
+};
 use crate::responses::{ApiResponse, ApiResponseExt};
-use crate::task::{TaskResult, TaskStatus};
-use crate::{execute, Database, TaskInfo, TaskRequest};
+use crate::task::{TaskId, TaskInfo, TaskRequest, TaskStatus};
+use crate::Database;
 use axum::extract::{Path, State};
-use axum::{routing::get, Json, Router};
-use std::net::SocketAddr;
-use tower_http::trace::TraceLayer;
-use uuid::Uuid;
+use axum::http;
+use axum::response::IntoResponseParts;
+use axum::{routing::get, routing::post, Json, Router};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::net::ToSocketAddrs;
+use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
+
+#[derive(Clone, Debug)]
+pub struct Configuration {
+    /// The interval at which workers should poll for more work.
+    ///
+    /// This value will be returned as a Retry-After header used by workers.
+    pub polling_interval: Duration,
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration {
+            polling_interval: Duration::from_secs(5),
+        }
+    }
+}
 
 #[derive(Clone)]
 struct AppState {
     database: Database,
-}
-
-/// This runs a marathon task in a background thread.
-///
-/// Eventually this will go away and be replaced by workers and a queue.
-fn execute_thread(
-    database: Database,
-    handle: tokio::runtime::Handle,
-    id: Uuid,
-    request: TaskRequest,
-) -> crate::Result<()> {
-    let _guard = tracing::info_span!("task", id = %id).entered();
-
-    handle.block_on(database.task_update(id, TaskStatus::Running))?;
-
-    let status = match execute(&request) {
-        Ok(TaskResult { status, .. }) => {
-            if status.success() {
-                TaskStatus::Complete
-            } else {
-                TaskStatus::Failed
-            }
-        }
-        Err(_) => TaskStatus::Failed,
-    };
-
-    handle.block_on(database.task_update(id, status))?;
-
-    Ok(())
+    config: Configuration,
 }
 
 async fn task_submit(
     State(state): State<AppState>,
     Json(request): Json<TaskRequest>,
 ) -> ApiResponse<TaskSubmitResponse> {
-    let id = state.database.task_create().await?;
-
-    // We need the handle to do database updates from the background thread.
-    let handle = tokio::runtime::Handle::current();
-
-    // Eventually this should add to a queue, rather than run immediately.
-    std::thread::spawn(move || {
-        if let Err(error) = execute_thread(state.database, handle, id, request) {
-            // Not a lot more we can do about it at this point. This only concerns unexpected
-            // errors (eg. updating the database). Errors caused by the actual task are caught and
-            // recorded in the database.
-            tracing::error!(%error, "error while processing task");
-        }
-    });
-
+    let id = state.database.task_create(&request).await?;
     ApiResponse::created(TaskSubmitResponse { id })
 }
 
-async fn task_get(Path(id): Path<Uuid>, State(state): State<AppState>) -> ApiResponse<TaskInfo> {
-    if let Some(task) = state.database.task_get_status(id).await? {
+async fn task_get(Path(id): Path<TaskId>, State(state): State<AppState>) -> ApiResponse<TaskInfo> {
+    if let Some(task) = state.database.task_get_info(id).await? {
         ApiResponse::success(task)
     } else {
         ApiResponse::not_found()
@@ -85,31 +64,78 @@ async fn fallback_handler() -> ApiResponse<()> {
     ApiResponse::bad_request()
 }
 
-pub async fn create_app() -> crate::Result<Router<()>> {
-    let state = AppState {
-        database: Database::open_in_memory().await.unwrap(),
-    };
-
-    Ok(Router::new()
-        .route("/", get(index))
-        .route("/tasks", get(task_list).post(task_submit))
-        .route("/tasks/{id}", get(task_get))
-        .fallback(fallback_handler)
-        .with_state(state)
-        .layer(TraceLayer::new_for_http()))
+async fn queue_pull(
+    State(state): State<AppState>,
+) -> ApiResponse<QueuePullResponse, impl IntoResponseParts> {
+    if let Some(task) = state.database.queue_pop().await? {
+        let request = state.database.task_get_request(task).await?;
+        ApiResponse::success(Some(QueuePullResponseInner { task, request })).with(None)
+    } else {
+        let interval = state.config.polling_interval.as_secs();
+        ApiResponse::success(None).with(Some([(http::header::RETRY_AFTER, interval)]))
+    }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn start(address: &SocketAddr) -> crate::Result<()> {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::TRACE)
-        .init();
+async fn queue_update(
+    State(state): State<AppState>,
+    Json(body): Json<QueueUpdateRequest>,
+) -> ApiResponse<()> {
+    match body.status {
+        TaskStatus::Running | TaskStatus::Complete | TaskStatus::Failed => (),
+        _ => return ApiResponse::bad_request(),
+    }
 
-    let app = create_app().await?;
+    state.database.task_update(body.task, body.status).await?;
 
-    let listener = tokio::net::TcpListener::bind(address).await?;
-    println!("listening on {}", listener.local_addr()?);
-    axum::serve(listener, app).await?;
+    ApiResponse::success(())
+}
 
-    Ok(())
+pub struct ApiServer {
+    router: Router<()>,
+}
+
+impl ApiServer {
+    #[tracing::instrument(name = "setup", skip_all)]
+    pub async fn new(config: Configuration) -> crate::Result<ApiServer> {
+        let state = AppState {
+            database: Database::open_in_memory().await.unwrap(),
+            config,
+        };
+
+        // These are DEBUG level by default, which we disable on external crates.
+        // Alternatively we could keep them at debug but ensure they are attributed to this crate so
+        // they would be logged.
+        let trace = TraceLayer::new_for_http()
+            .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO))
+            .on_request(DefaultOnRequest::new().level(tracing::Level::INFO))
+            .on_response(DefaultOnResponse::new().level(tracing::Level::INFO));
+
+        let router = Router::new()
+            .route("/", get(index))
+            .route("/tasks", get(task_list).post(task_submit))
+            .route("/tasks/{id}", get(task_get))
+            .route("/queue/pull", post(queue_pull))
+            .route("/queue/task", post(queue_update))
+            .fallback(fallback_handler)
+            .with_state(state)
+            .layer(trace);
+
+        Ok(ApiServer { router })
+    }
+
+    /// Start listening on the given address.
+    ///
+    /// This may be called multiple times to listen on multiple addresses.
+    /// The returned future must be awaited in order to process requests.
+    pub async fn listen(
+        &self,
+        addr: impl ToSocketAddrs,
+    ) -> crate::Result<axum::serve::Serve<TcpListener, Router, Router>> {
+        let listener = TcpListener::bind(addr).await?;
+        let addr = listener.local_addr()?;
+
+        tracing::info!("listening on {addr}");
+
+        Ok(axum::serve(listener, self.router.clone()))
+    }
 }

--- a/api/src/task.rs
+++ b/api/src/task.rs
@@ -3,6 +3,32 @@ use std::collections::HashMap;
 use std::process::ExitStatus;
 use uuid::Uuid;
 
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, Eq, PartialEq, sqlx::Type)]
+#[serde(transparent)]
+#[sqlx(transparent)]
+pub struct TaskId(Uuid);
+
+impl TaskId {
+    /// Generate a new random task ID.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> TaskId {
+        TaskId(Uuid::now_v7())
+    }
+}
+
+impl std::fmt::Display for TaskId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::str::FromStr for TaskId {
+    type Err = <Uuid as std::str::FromStr>::Err;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Uuid::from_str(s).map(TaskId)
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct TaskRequest {
     pub cmdline: Vec<String>,
@@ -17,7 +43,7 @@ pub struct TaskResult {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, sqlx::FromRow)]
 pub struct TaskInfo {
-    pub id: Uuid,
+    pub id: TaskId,
     pub status: TaskStatus,
 }
 
@@ -27,6 +53,7 @@ pub struct TaskInfo {
 #[serde(rename_all = "UPPERCASE")]
 pub enum TaskStatus {
     Pending,
+    Claimed,
     Running,
     Complete,
     Failed,
@@ -37,8 +64,29 @@ impl TaskStatus {
     pub fn is_finished(self) -> bool {
         use TaskStatus::*;
         match self {
-            Pending | Running => false,
+            Pending | Claimed | Running => false,
             Complete | Failed => true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assertor::*;
+
+    #[test]
+    fn task_id_is_unique() {
+        let id1 = TaskId::new();
+        let id2 = TaskId::new();
+        assert_that!(id1).is_not_equal_to(id2);
+    }
+
+    #[test]
+    fn can_round_trip_task_id() {
+        let id = TaskId::new();
+        assert_that!(id.to_string().parse::<TaskId>())
+            .ok()
+            .is_equal_to(id);
     }
 }

--- a/api/src/tests.rs
+++ b/api/src/tests.rs
@@ -1,11 +1,11 @@
+use crate::server::{ApiServer, Configuration};
 use crate::task::{TaskInfo, TaskRequest, TaskStatus};
-use crate::{server::create_app, Client};
+use crate::{worker, Client};
 use assertor::*;
 use reqwest::Url;
 use std::collections::HashMap;
 use std::future::IntoFuture;
 use std::time::{Duration, Instant};
-use tokio::net::TcpListener;
 use tokio::runtime;
 use tokio::sync::oneshot;
 
@@ -16,15 +16,18 @@ struct BackgroundRuntime(#[allow(unused)] oneshot::Sender<()>);
 ///
 /// The server needs a Tokio runtime to run. When the returned `BackgroundRuntime` object is
 /// dropped, this informs the runtime that it needs to shutdown.
-fn start() -> anyhow::Result<(Client, BackgroundRuntime)> {
+fn start_server() -> anyhow::Result<(Client, BackgroundRuntime)> {
     let rt = runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
 
-    let app = rt.block_on(create_app())?;
+    let config = Configuration {
+        polling_interval: Duration::from_secs(0),
+    };
+    let app = rt.block_on(ApiServer::new(config))?;
 
     // Bind on a random port and then find out what port was used so we can create the client.
-    let listener = rt.block_on(TcpListener::bind("127.0.0.1:0"))?;
+    let listener = rt.block_on(app.listen("127.0.0.1:0"))?;
     let addr = listener.local_addr()?;
 
     // This channel is used to shutdown the background thread. We never actually write anything to
@@ -33,7 +36,7 @@ fn start() -> anyhow::Result<(Client, BackgroundRuntime)> {
 
     std::thread::spawn(move || {
         rt.block_on(async {
-            tokio::spawn(axum::serve(listener, app).into_future());
+            tokio::spawn(listener.into_future());
             // This will block until the sender is dropped, at which point we return, stop the
             // runtime and close the server.
             let _ = rx.await;
@@ -55,7 +58,7 @@ where
     F: Fn() -> anyhow::Result<bool>,
 {
     // Nothing we test for should take a long time. 1 second is plenty of time.
-    let deadline = Instant::now() + Duration::from_secs(1);
+    let deadline = Instant::now() + Duration::from_secs(2);
     while Instant::now() < deadline {
         if f()? {
             return Ok(());
@@ -64,9 +67,11 @@ where
     anyhow::bail!("timeout")
 }
 
-#[test]
+#[test_log::test]
 fn can_submit_task() -> anyhow::Result<()> {
-    let (client, _rt) = start()?;
+    let (client, _rt) = start_server()?;
+    let _worker = worker::run_background(client.url().clone());
+
     let id = client.task_submit(&TaskRequest {
         environment: HashMap::new(),
         cmdline: vec!["true".to_owned()],
@@ -85,9 +90,11 @@ fn can_submit_task() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
+#[test_log::test]
 fn failed_tasks_have_appropriate_status() -> anyhow::Result<()> {
-    let (client, _rt) = start()?;
+    let (client, _rt) = start_server()?;
+    let _worker = worker::run_background(client.url().clone());
+
     // These two commands fail in different ways: the first one has a non-zero exit code whereas
     // the second one does not even start. We don't yet have any way of distinguishing between the
     // two cases.
@@ -109,9 +116,11 @@ fn failed_tasks_have_appropriate_status() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
+#[test_log::test]
 fn can_list_tasks() -> anyhow::Result<()> {
-    let (client, _rt) = start()?;
+    let (client, _rt) = start_server()?;
+    let _worker = worker::run_background(client.url().clone());
+
     let id1 = client.task_submit(&TaskRequest {
         environment: HashMap::new(),
         cmdline: vec!["true".to_owned()],

--- a/api/src/worker.rs
+++ b/api/src/worker.rs
@@ -1,0 +1,61 @@
+use crate::task::{TaskId, TaskRequest, TaskResult, TaskStatus};
+use crate::Client;
+use reqwest::Url;
+use std::sync::mpsc;
+use std::time::Duration;
+
+#[tracing::instrument(skip_all, fields(task = %id))]
+fn process_task(client: &Client, id: TaskId, request: &TaskRequest) -> crate::Result<()> {
+    client.queue_update(id, TaskStatus::Running)?;
+
+    let status = match crate::execute(request) {
+        Ok(TaskResult { status, .. }) => {
+            if status.success() {
+                TaskStatus::Complete
+            } else {
+                TaskStatus::Failed
+            }
+        }
+        Err(_) => TaskStatus::Failed,
+    };
+
+    client.queue_update(id, status)?;
+
+    Ok(())
+}
+
+#[tracing::instrument(name = "worker", skip_all)]
+fn run_inner(url: Url, shutdown: mpsc::Receiver<()>) -> anyhow::Result<()> {
+    let client = Client::new(url);
+    loop {
+        tracing::info!("Polling for new tasks");
+        match client.queue_pull()? {
+            Ok(data) => process_task(&client, data.task, &data.request)?,
+            Err(interval) => {
+                let interval = interval.unwrap_or(Duration::from_secs(5));
+                match shutdown.recv_timeout(interval) {
+                    Ok(_) => unreachable!(),
+                    Err(mpsc::RecvTimeoutError::Timeout) => (),
+                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn run(url: Url) -> crate::Result<()> {
+    let (_tx, rx) = mpsc::channel();
+    run_inner(url, rx)
+}
+
+pub struct BackgroundWorker(#[allow(unused)] mpsc::Sender<()>);
+pub fn run_background(url: Url) -> BackgroundWorker {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        if let Err(error) = run_inner(url, rx) {
+            tracing::error!(%error, "background worker thread failed");
+        }
+    });
+    BackgroundWorker(tx)
+}


### PR DESCRIPTION
The worker now runs outside of the server process and communicates with it over HTTP. There is one endpoint used to pull tasks from a work queue and one endpoint to update the task's status.

The task queue is recorded in the SQLite database as its own table. While it would be possible to maintain the queue as part of the main task table, I think the separation of concern is good to have. In particular the task table will be synchronized across the client and the server, whereas the work queue does not need to be (and probably should not).

It would have also been possible to maintain the queue in memory, although we would then need to worry about maintaining atomicity when adding or updating new tasks. Using the database is just simpler as it allows us to use transactions.

As a convenience, the server command has a `--start-worker` flag that will run a worker thread concurrently. This is useful in local development and removes the need to have yet another console open.